### PR TITLE
refactor: 매장 조회 쿼리 성능 개선

### DIFF
--- a/src/main/java/com/ijaes/jeogiyo/store/controller/StoreAdminController.java
+++ b/src/main/java/com/ijaes/jeogiyo/store/controller/StoreAdminController.java
@@ -39,7 +39,6 @@ public class StoreAdminController {
 		@RequestParam(defaultValue = "10") int size,
 		@RequestParam(defaultValue = "createdAt") String sortBy,
 		@RequestParam(defaultValue = "DESC") String direction) {
-
 		Page<StoreResponse> response = storeAdminService.getAllStores(page, size, sortBy, direction);
 		return ResponseEntity.ok(response);
 	}


### PR DESCRIPTION
## 📄 PR 내용

<!--- 작업에 대한 요약 설명을 작성해 주세요. -->

- `StoreRepositoryCustom` 성능 및 안정성 개선
- 페이징 `total` 계산을 `COUNT(*)`로 교체
- 2-쿼리 전략(count + content) 적용

## 📝 수정 상세 내용

<!--- 작업 전과 후의 변화를 설명해 주세요. -->
### 페이지 total 계산 최적화
- Before: `query.fetch().size()`로 전체 로우를 실제로 가져와서 size 계산 (비효율적임)
- After: `select(store.count())`로 DB 집계만 요청 -> `findAllNotDeleted`, `findAllIncludingDeleted` 모두 적용

### 존재 여부는 id만 가져오기 + 조기 종료
- Before: `selectOne()` 후 `fetchFirst() != null`
- After: `select(store.id).limit(1).fetchFirst()` -> 가벼운 컬럼만 조회 + 한 건 찾으면 즉시 종료

### 단건 조회의 안정성
- Before: `fetchOne()` -> 다건 시 예외
- After: `limit(1).fetchFirst()` -> 유일성 보장이 확실하지 않아도 예외 없이 첫 행만 반환

### 삭제 포함 목록 페이징 정렬 유지
- 동일하게 `orderBy(store.createdAt.desc()) + offset/limit` 유지 -> 목록 일관성 보장

## 📍 레퍼런스

- X