### PR TITLE
feat: 본인 매장에 등록된 리뷰 조회

### DIFF
--- a/src/main/java/com/ijaes/jeogiyo/auth/config/SecurityConfig.java
+++ b/src/main/java/com/ijaes/jeogiyo/auth/config/SecurityConfig.java
@@ -49,6 +49,7 @@ public class SecurityConfig {
 					"/webjars/**"
 				).permitAll()
 				.requestMatchers("/v1/admin/**").hasRole("MANAGER")
+				.requestMatchers("/v1/owner/**").hasRole("OWNER")
 				.requestMatchers("/v1/users/**").authenticated()
 				.anyRequest().authenticated()
 			)

--- a/src/main/java/com/ijaes/jeogiyo/review/controller/ReviewOwnerController.java
+++ b/src/main/java/com/ijaes/jeogiyo/review/controller/ReviewOwnerController.java
@@ -1,0 +1,37 @@
+package com.ijaes.jeogiyo.review.controller;
+
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ijaes.jeogiyo.review.dto.response.ReviewResponse;
+import com.ijaes.jeogiyo.review.service.ReviewOwnerService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/v1/owner/reviews")
+@RequiredArgsConstructor
+@Tag(name = "사장님")
+public class ReviewOwnerController {
+
+	private final ReviewOwnerService reviewOwnerService;
+
+	@GetMapping
+	@Operation(summary = "리뷰 조회", description = "본인 매장에 등록된 리뷰를 조회합니다", security = @SecurityRequirement(name = "bearer-jwt"))
+	public ResponseEntity<Page<ReviewResponse>> getMyStoreReviews(
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "10") int size,
+		Authentication authentication
+	) {
+		Page<ReviewResponse> response = reviewOwnerService.getMyStoreReviews(page, size, authentication);
+		return ResponseEntity.ok(response);
+	}
+}

--- a/src/main/java/com/ijaes/jeogiyo/review/service/ReviewOwnerService.java
+++ b/src/main/java/com/ijaes/jeogiyo/review/service/ReviewOwnerService.java
@@ -1,0 +1,31 @@
+package com.ijaes.jeogiyo.review.service;
+
+import org.springframework.data.domain.Page;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.ijaes.jeogiyo.common.exception.CustomException;
+import com.ijaes.jeogiyo.common.exception.ErrorCode;
+import com.ijaes.jeogiyo.review.dto.response.ReviewResponse;
+import com.ijaes.jeogiyo.store.entity.Store;
+import com.ijaes.jeogiyo.store.repository.StoreRepository;
+import com.ijaes.jeogiyo.user.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewOwnerService {
+
+	private final ReviewService reviewService;
+	private final StoreRepository storeRepository;
+
+	@Transactional(readOnly = true)
+	public Page<ReviewResponse> getMyStoreReviews(int page, int size, Authentication authentication) {
+		User owner = (User)authentication.getPrincipal();
+		Store store = storeRepository.findByOwnerId(owner.getId())
+			.orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
+		return reviewService.getStoreReviews(authentication, store.getId(), page, size);
+	}
+}


### PR DESCRIPTION
## 📄 PR 내용

<!--- 작업에 대한 요약 설명을 작성해 주세요. -->

- 사장님이 본인 매장에 등록된 리뷰를 조회할 수 있는 API를 구현했습니다.

## 📝 수정 상세 내용

<!--- 작업 전과 후의 변화를 설명해 주세요. -->


  ### API 엔드포인트 추가
  - `GET /v1/owner/reviews` - 본인 매장에 등록된 리뷰 목록 조회 (페이징)
    - 권한: OWNER 역할 필요
    - 파라미터: `page` (default: 0), `size` (default: 10)
    - 응답: `Page<ReviewResponse>`

  ### 새로운 파일
  - `ReviewOwnerController.java` - 사장님용 리뷰 조회 컨트롤러
  - `ReviewOwnerService.java` - 사장님용 리뷰 비즈니스 로직

  ### 보안 설정
  - `SecurityConfig.java`에 `/v1/owner/**` 경로에 대한 OWNER 역할 체크 추가

  ### 구현 세부사항
  - 인증된 사장님의 매장을 조회 후, 해당 매장의 리뷰 목록 반환
  - 기존 `ReviewService.getStoreReviews()` 재사용으로 코드 중복 방지
  - 페이징 처리로 대량 데이터 효율적 처리
  - `@Transactional(readOnly = true)`로 읽기 최적화

  ### 에러 처리
  - 매장이 없는 경우: `STORE_NOT_FOUND` 예외 반환
  - OWNER 역할이 아닌 경우: 403 Forbidden


## 📍 레퍼런스

- X