### PR TITLE
refactor: 주문 관련 API 수정

### DIFF
--- a/src/main/java/com/ijaes/jeogiyo/common/exception/ErrorCode.java
+++ b/src/main/java/com/ijaes/jeogiyo/common/exception/ErrorCode.java
@@ -76,6 +76,7 @@ public enum ErrorCode {
 	ORDER_ALREADY_DELETED(HttpStatus.BAD_REQUEST, "O-008", "이미 삭제된 주문입니다."), // 소프트 삭제된 주문에 대한 방어
 	ORDER_EVENT_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "O-009", "주문 이벤트 발행 중 오류가 발생했습니다."), // 메세지 수정
 	ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "O-0010", "주문을 찾을 수 없습니다."),
+	ORDER_REFUND_INVALID_STATE(HttpStatus.CONFLICT, "O-0011", "환불을 진행할 수 없는 주문 상태입니다."),
 
 	// 결제 관련 (P-xxx)
 	PAYMENT_KEY_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "P-001", "결제 키 발급 중 오류가 발생했습니다."),

--- a/src/main/java/com/ijaes/jeogiyo/orders/entity/OrderStatus.java
+++ b/src/main/java/com/ijaes/jeogiyo/orders/entity/OrderStatus.java
@@ -12,18 +12,20 @@ public enum OrderStatus {
 	DELIVERED,
 	COMPLETED,
 	CANCELED,  // 최종(미결제 취소)
+	REFUND_PENDING, // ★ 추가: 환불 진행 중(비동기 대기)
 	REFUND;    // 최종(결제 취소-환불)
 
 	// 정상 진행 전이 (취소/환불 특례는 도메인 메서드에서 직접 처리)
 	private static final Map<OrderStatus, Set<OrderStatus>> ALLOWED_NEXT = Map.of(
-		ACCEPTED, Set.of(PAID, CANCELED, REFUND),         // 결제 후에만 진행
-		PAID, Set.of(COOKING, CANCELED, REFUND),
+		ACCEPTED, Set.of(PAID, CANCELED, REFUND_PENDING),
+		PAID, Set.of(COOKING, CANCELED, REFUND_PENDING),
 		COOKING, Set.of(COOKED),
 		COOKED, Set.of(DELIVERING),
 		DELIVERING, Set.of(DELIVERED),
 		DELIVERED, Set.of(COMPLETED),
 		COMPLETED, Set.of(),
 		CANCELED, Set.of(),
+		REFUND_PENDING, Set.of(REFUND), // ★ 추가: 대기 → 완료
 		REFUND, Set.of()
 	);
 

--- a/src/main/java/com/ijaes/jeogiyo/payments/entity/Payment.java
+++ b/src/main/java/com/ijaes/jeogiyo/payments/entity/Payment.java
@@ -50,7 +50,7 @@ public class Payment extends BaseEntity {
 	@Column
 	private int paymentAmount;
 
-	@Column(nullable = false)
+	@Column(name = "payment_key", length = 191)
 	private String paymentKey;
 
 	@Column(nullable = false)


### PR DESCRIPTION
## 📄 PR 내용

<!--- 작업에 대한 요약 설명을 작성해 주세요. -->

- Order 도메인 규칙 추가, OrderService 이벤트 관련 수정, OrderStatus 값 추가
- Payment 수정, ErrorCode 추가

## 📝 수정 상세 내용

<!--- 작업 전과 후의 변화를 설명해 주세요. -->

- 도메인 이벤트 기반으로 결제 상태를 처리하도록 변경
- OrderStatus에 결제 대기상태인 REFUND_PENDING 추가
- OrderService는 상태를 직접 변경하지 않고, 이벤트 발행으로 도메인 메서드가 상태 변경하도록 수정
- Payment에 paymentkey nullable로 변경 - DB컬럼 반영
- ERRORCode로 '환불을 진행할 수 없는 상태' 에레 코드 추가


## 📍 레퍼런스

- 